### PR TITLE
fix after many years of GHC / Hackage changes

### DIFF
--- a/envstatus.cabal
+++ b/envstatus.cabal
@@ -21,7 +21,7 @@ library
                      , EnvStatus.Output.Types
                      , EnvStatus.Process
   -- other-extensions:
-  build-depends:       base >=4.11 && <4.12
+  build-depends:       base
                      , ConfigFile >= 1.1 && <1.2
                      , mtl >= 2.2 && <2.3
                      , parsec >= 3.1 && < 3.2
@@ -43,11 +43,12 @@ test-suite envstatus-test
   hs-source-dirs:     test
   main-is:            Spec.hs
   build-depends:      base
-                    , parsec >= 3.1 && < 3.2
-                    , tasty >= 1.1 && < 1.2
-                    , tasty-hspec >= 1.1 && < 1.2
+                    , parsec
+                    , hspec
+                    , tasty
+                    , tasty-hspec
                     , ConfigFile >= 1.1 && <1.2
-                    , PyF >= 0.6 && <0.7
+                    , PyF
                     , envstatus
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:   Haskell2010

--- a/src/EnvStatus/Config.hs
+++ b/src/EnvStatus/Config.hs
@@ -1,7 +1,7 @@
 module EnvStatus.Config where
 
 import System.Posix.Files (fileExist)
-import System.Posix.User (getRealUserID, getUserEntryForID, UserEntry(..))
+import System.Posix.User
 
 import Data.ConfigFile (ConfigParser, readstring, emptyCP, get, set, merge, to_string)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,5 @@
 import Test.Tasty
 
-import Control.Applicative ((<$>))
-import Control.Monad (sequence)
-
 import Test.EnvStatus.Config (configTests)
 import Test.EnvStatus.Output.Parse (parseTests)
 import Test.EnvStatus.Output.Render (renderTests)

--- a/test/Test/EnvStatus/Config.hs
+++ b/test/Test/EnvStatus/Config.hs
@@ -5,12 +5,13 @@ module Test.EnvStatus.Config (configTests) where
 import Data.ConfigFile (emptyCP, get, to_string, ConfigParser)
 import Data.Either
 import Data.Maybe
-import PyF
+import PyF hiding (defaultConfig)
 
 import Test.Tasty
 import Test.Tasty.Hspec
 
 import EnvStatus.Config
+import Test.Hspec
 
 -- HLint config have to be put after the imports
 {-# ANN module "HLint: ignore Redundant do" #-}
@@ -21,7 +22,7 @@ sectionName = "Section"
 sectionKey = "k2"
 sectionValue = "v2"
 
-dummyConfigString = [fString|{defaultKey}: {defaultValue}\n[{sectionName}]\n{sectionKey}: {sectionValue}|]
+dummyConfigString = [fmt|{defaultKey}: {defaultValue}\n[{sectionName}]\n{sectionKey}: {sectionValue}|]
 
 dummyConfig :: IO ConfigParser
 dummyConfig = readConfig dummyConfigString

--- a/test/Test/EnvStatus/Output/Parse.hs
+++ b/test/Test/EnvStatus/Output/Parse.hs
@@ -1,11 +1,11 @@
 module Test.EnvStatus.Output.Parse (parseTests) where
 
-import Control.Applicative ((<*))
 import Data.Either (isLeft)
 import Test.Tasty
 import Test.Tasty.Hspec
 import Text.Parsec (parse, try)
 import Text.Parsec.Char (anyChar)
+import Test.Hspec
 
 import EnvStatus.Output.Parse
 import EnvStatus.Output.Types

--- a/test/Test/EnvStatus/Output/Render.hs
+++ b/test/Test/EnvStatus/Output/Render.hs
@@ -4,6 +4,7 @@ import Test.Tasty
 import Test.Tasty.Hspec
 
 import EnvStatus.Output.Render
+import Test.Hspec
 
 -- HLint config have to be put after the imports
 {-# ANN module "HLint: ignore Redundant do" #-}


### PR DESCRIPTION
- I mostly removed bounds in cabal file. I'm too lazy to test everything and ensure that it works fine, so I rather prefer no bounds than incorrect ones.
- `Test.Hspec` symbols are no longer in the reexports of `tasty-hspec`
- `PyF` `fString` was replaced by `fmt` something like 125 years ago, maybe it was in previous century.
- `System.Posix.User` changed a bit its names, so explicit import does not work anymore, but type inference works, so we are good.

Tested with GHC 9.0 -> 9.8.

Note that however I did not tested that it builds correctly with an old stack snapshot